### PR TITLE
Update startup.sh to play nicely with Firefox

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -3,5 +3,6 @@
 while true; do
     python pucauto.py
     echo Restarting...
+    killall firefox
     sleep 3
 done


### PR DESCRIPTION
Sometimes extra copies of Firefox end up laying around. This may be okay on a high-performance desktop system but is less great on a low footprint machine like a Raspberry Pi or small virtual server. This kills all copies of Firefox laying around before restarting. NOTE: This may be something we want to mention in readme for home users who nuke their own other instances of Firefox that are open.
