### PR TITLE
Canceling trades if the minimum value isn't reached

### DIFF
--- a/pucauto.py
+++ b/pucauto.py
@@ -349,7 +349,7 @@ def complete_trades(highest_value_bundle):
         success_count, len(sorted_cards), success_value))
 
     # See if enough cards have made it trough
-    if success_value >= CONFIG["min_value"]:
+    if success_value < CONFIG["min_value"]:
         print("The successful shipping value is under your minimum value, removing cards...")
         remove_unshipped_trades(member_name)
         


### PR DESCRIPTION
So I noticed sometimes the bots want to send ~20 cards for 400 points (for example, when my min_val is 300) and a lot of trades would fail due to faster speed of other people or I don't know why. (Reason: Trade Impossible). The few cards that made it trough often don't reach my minimum value.  
So far I was lucky enough to get them all in the half hour period where you can cancel them, but this isn't always the case.  

I updated it so it checks after all the cards where sent if the minimum value was reached, and if not cancels all the outgoing trades made from that.  
I hope I hit your function naming / commenting style right, also I accidently made a merge commit message, sorry about that.
